### PR TITLE
feature: Add completed tasks section

### DIFF
--- a/web/src/lib/components/TaskBoard.svelte
+++ b/web/src/lib/components/TaskBoard.svelte
@@ -3,14 +3,18 @@
     import type { Task } from "$lib/apiClient";
     import type { DndEvent, DndZoneOptions } from "svelte-dnd-action";
     import TaskColumn from "./TaskColumn.svelte";
+    import TaskCard from "./TaskCard.svelte";
 
     export let backlogTasks: Task[] = [];
     export let scheduledTasks: Task[] = [];
+    export let completedTasks: Task[] = [];
 
     const dispatch = createEventDispatcher<{
         consider: DndEvent<Task>;
         finalize: DndEvent<Task>;
         select: { task: Task };
+        complete: { task: Task };
+        reopen: { task: Task };
     }>();
 
     $: backlogOptions = { id: "backlog", items: backlogTasks } satisfies DndZoneOptions<Task>;
@@ -23,6 +27,16 @@
     function forwardSelect(event: CustomEvent<{ task: Task }>) {
         dispatch("select", event.detail);
     }
+
+    function forwardComplete(event: CustomEvent<{ task: Task }>) {
+        dispatch("complete", event.detail);
+    }
+
+    function forwardReopen(event: CustomEvent<{ task: Task }>) {
+        dispatch("reopen", event.detail);
+    }
+
+    let showCompleted = false;
 </script>
 
 <div class="grid grid-cols-1 md:grid-cols-2 gap-4 p-2 w-full">
@@ -33,6 +47,7 @@
         on:consider={forward}
         on:finalize={forward}
         on:select={forwardSelect}
+        on:complete={forwardComplete}
     />
     <TaskColumn
         title="Scheduled"
@@ -41,5 +56,35 @@
         on:consider={forward}
         on:finalize={forward}
         on:select={forwardSelect}
+        on:complete={forwardComplete}
     />
+</div>
+
+<div class="px-2 mt-3 w-full">
+    <details class="rounded-xl border border-gray-200 bg-gray-50" bind:open={showCompleted}>
+        <summary
+            class="w-full flex items-center justify-between px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 transition cursor-pointer select-none list-none"
+            role="button"
+            aria-expanded={showCompleted}
+        >
+            <div class="flex items-center gap-2">
+                <span class="text-gray-600">{showCompleted ? "▾" : "▸"}</span>
+                <span class="font-semibold">Completed</span>
+                <span class="text-xs text-gray-500 bg-gray-200 px-2 py-0.5 rounded-full"
+                    >{completedTasks.length}</span
+                >
+            </div>
+            <span class="text-xs text-gray-500">{showCompleted ? "Hide" : "Show"}</span>
+        </summary>
+
+        <div class="mt-1 mb-2 px-2 flex flex-col gap-2">
+            {#if completedTasks.length > 0}
+                {#each completedTasks as task (task.id)}
+                    <TaskCard task={task} draggable={false} on:reopen={forwardReopen} />
+                {/each}
+            {:else}
+                <div class="text-sm text-gray-400 italic px-1">No completed tasks yet.</div>
+            {/if}
+        </div>
+    </details>
 </div>

--- a/web/src/lib/components/TaskColumn.svelte
+++ b/web/src/lib/components/TaskColumn.svelte
@@ -12,6 +12,7 @@
         consider: DndEvent<Task>;
         finalize: DndEvent<Task>;
         select: { task: Task };
+        complete: { task: Task };
     }>();
 
     const forward =
@@ -21,6 +22,10 @@
 
     const forwardSelect = (event: CustomEvent<{ task: Task }>) => {
         dispatch("select", event.detail);
+    };
+
+    const forwardComplete = (event: CustomEvent<{ task: Task }>) => {
+        dispatch("complete", event.detail);
     };
 
     $: resolvedOptions =
@@ -47,7 +52,12 @@
     <div class="flex flex-col space-y-2 overflow-y-auto max-h-[70vh] p-3">
         {#if tasks.length > 0}
             {#each tasks as task (task.id)}
-                <TaskCard {task} on:select={forwardSelect} />
+                <TaskCard
+                    {task}
+                    showCompleteButton
+                    on:select={forwardSelect}
+                    on:complete={forwardComplete}
+                />
             {/each}
         {:else}
             <div class="text-sm text-gray-400 italic">No tasks yet.</div>


### PR DESCRIPTION
## Summary
- Add completion and reopen actions to task cards, showing completed items in a collapsible “Completed” section on the board.
- Keep completed tasks visible on the timeline with a distinct style while ensuring planned tasks render above completed ones.
- Wire UI events through to update tasks via the backend for both completing and reopening, keeping board and timeline lists in sync.

## Test Plan
- Mark a backlog/scheduled task as completed; it should disappear from its column and appear under “Completed.”
- Click the “Completed” tag on a completed task; it should return to the appropriate list (planned if it retained times, otherwise backlog).
- Verify overlapping tasks on the timeline: planned items should render above completed items, and completed items should appear greyed.