### PR TITLE
fix: Update CI workflow to run on staging branch PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, staging]
   pull_request:
-    branches: [main]
+    branches: [main, staging]
 
 concurrency:
   group: ci-${{ github.ref }}


### PR DESCRIPTION
## Overview

This PR fixes the CI workflow to run on pull requests targeting the `staging` branch, which is our integration branch.

## Problem

The CI workflow was only configured to run on:
- PRs targeting `main`
- Direct pushes to `main`

But our workflow uses `staging` as the integration branch where all feature branches merge first. This meant PRs targeting `staging` had no CI checks, blocking merges.

## Solution

Updated the workflow triggers to include both `main` and `staging`:

```yaml
on:
  push:
    branches: [main, staging]
  pull_request:
    branches: [main, staging]
```

## Impact

- CI now runs on all PRs targeting `staging`
- CI runs on all PRs targeting `main`
- CI runs on direct pushes to either branch
- Enables proper branch protection and merge requirements

This is a prerequisite for other PRs that need CI to pass before merging to `staging`.