### PR TITLE
chore: remove temporary feature branch from deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - staging
       - main
-      - feature/automated-env-deployment-and-volume-persistence  # TEMPORARY: For testing
   workflow_run:
     workflows: ["CI"]
     types:


### PR DESCRIPTION
Removes the temporary `feature/automated-env-deployment-and-volume-persistence` branch from the deploy workflow trigger branches.