### PR TITLE
fix: Keep EigenTask branding on one line and center logo on login page

### DIFF
--- a/keycloak/themes/eigentask/login/resources/css/eigentask.css
+++ b/keycloak/themes/eigentask/login/resources/css/eigentask.css
@@ -65,8 +65,10 @@
   display: block;
   width: 2.5rem;
   height: 2.5rem;
-  background: url("../img/logo.svg") center/contain no-repeat;
+  margin-left: auto;
+  margin-right: auto;
   margin-bottom: 0.25rem;
+  background: url("../img/logo.svg") center/contain no-repeat;
 }
 
 .kc-logo-text span {


### PR DESCRIPTION
## Summary

Fixes Keycloak login page branding: "EigenTask" was rendering on two lines ("Eigen" and "Task" on separate lines), and the logo was no longer centered after the initial fix.

## Changes

- **Branding on one line**: `.kc-logo-text` was using `flex-direction: column`, which stacked the two spans from the realm `displayNameHtml`. Switched to `display: block` with `text-align: center` and made the spans `display: inline` so "EigenTask" stays on one line.
- **Logo centering**: The logo is rendered via `.kc-logo-text::before` (block). Added `margin-left: auto` and `margin-right: auto` so the logo block is horizontally centered.

## Verification

- [x] Login page shows "EigenTask" on a single line
- [x] Logo is horizontally centered
- [x] Tagline "Plan. Schedule. Finish." remains on its own line below