### PR TITLE
fix: Prod volume reuse, no prune volumes, create branches from staging

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Contribution Branch → Staging → Main (Production)
 
 All development happens on contribution branches with the naming convention above:
 
-- Create from `main`: `git checkout -b <type>/<description> main`
+- Create from `staging`: `git checkout -b <type>/<description> staging`
   - Examples: `feature/user-dashboard`, `fix/auth-bug`, `docs/api-guide`, `refactor/auth-module`, `chore/update-deps`
 - Make changes with clear, focused commits
 - Open a Pull Request targeting `staging`
@@ -190,12 +190,13 @@ This workflow ensures:
 
 ## High Level Overview
 
-1) Create a contribution branch from `main` using the naming convention with the appropriate prefix:
+1) Create a contribution branch from `staging` using the naming convention with the appropriate prefix:
    - `feature/` for new features
    - `fix/` for bug fixes
    - `docs/` for documentation
    - `refactor/` for refactoring
    - `chore/` for maintenance tasks
+   - Example: `git checkout -b fix/my-fix staging`
 2) Make changes with clear, focused commits.
 3) If you change models:
    - Update SQLAlchemy models.

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -65,8 +65,14 @@ services:
 
 volumes:
   keycloak_db_data_prod:
+    external: true
+    name: keycloak_db_data
   app_db_data_prod:
+    external: true
+    name: eigentask_app_db_data
   redis_data_prod:
+    external: true
+    name: eigentask_redis_data
 
 networks:
   eigentask-prod:

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -139,14 +139,11 @@ ssh ${DEPLOY_USER}@${DEPLOY_HOST} << EOF
     echo "Checking disk space..."
     df -h
     
-    echo "Cleaning up Docker to free space..."
-    docker system prune -af --volumes || true
+    echo "Cleaning up Docker to free space (images only, never volumes)..."
+    docker system prune -af || true
     
     echo "Checking disk space..."
     df -h
-    
-    echo "Cleaning up Docker to free space..."
-    docker system prune -af --volumes || true
     
     echo "Checking Docker Buildx version..."
     docker buildx version || echo "Buildx not installed or outdated"


### PR DESCRIPTION
**Changes**

- **docker-compose.prod.yml**: Use external volumes (`keycloak_db_data`, `eigentask_app_db_data`, `eigentask_redis_data`) so the first prod deploy reuses legacy data without migration.
- **scripts/deploy.sh**: Remove `--volumes` from `docker system prune` so CI never deletes volumes.
- **README**: Contribution branches are created from `staging` (not `main`); staging has the latest. Updated High Level Overview and Contribution Branches sections.