### PR TITLE
fix: Patch OIDC discovery mock at router use site so auth tests pass

### DIFF
--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -179,7 +179,8 @@ def mock_oidc_discovery() -> Iterator[MagicMock]:
         "end_session_endpoint": "https://keycloak.test/realms/test-realm/protocol/openid-connect/logout",
     }
 
-    with patch("app.core.auth.get_discovery_document", new_callable=AsyncMock) as mock:
+    # Patch where it's used (router imports get_discovery_document at load time)
+    with patch("app.routers.auth.get_discovery_document", new_callable=AsyncMock) as mock:
         mock.return_value = discovery_doc
         yield mock
 


### PR DESCRIPTION
**Problem**

Auth tests were failing on main with 503: the mock for OIDC discovery was patching `app.core.auth.get_discovery_document`, but the auth router does `from app.core.auth import get_discovery_document` at load time, so it holds a reference to the real function and the mock never applied.

**Fix**

Patch where the function is used: `app.routers.auth.get_discovery_document` instead of `app.core.auth.get_discovery_document`. All 36 API tests pass after this change.