### PR TITLE
chore: Stage env files on server at /etc/eigentask/production and staging

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -61,11 +61,6 @@ jobs:
           GITHUB_REF_NAME: ${{ github.ref_name }}
           GITHUB_SHA: ${{ github.event.workflow_run.head_sha || github.sha }}
           ENVIRONMENT: ${{ github.ref_name == 'main' && 'production' || 'staging' }}
-          API_ENV: ${{ secrets.API_ENV }}
-          WEB_ENV: ${{ secrets.WEB_ENV }}
-          APP_DB_ENV: ${{ secrets.APP_DB_ENV }}
-          KEYCLOAK_ENV: ${{ secrets.KEYCLOAK_ENV }}
-          KEYCLOAK_DB_ENV: ${{ secrets.KEYCLOAK_DB_ENV }}
         run: |
           chmod +x ./scripts/deploy.sh
           ./scripts/deploy.sh

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -4,7 +4,7 @@ services:
   keycloak-db:
     container_name: eigentask-prod-keycloak-db
     env_file:
-      - ${ENV_FILE_PATH:-/etc/eigentask}/prod/keycloak-db.env
+      - ${ENV_FILE_PATH:-/etc/eigentask}/production/keycloak-db.env
     volumes:
       - keycloak_db_data_prod:/var/lib/postgresql/data
     networks:
@@ -13,12 +13,12 @@ services:
   keycloak:
     container_name: eigentask-prod-keycloak
     env_file:
-      - ${ENV_FILE_PATH:-/etc/eigentask}/prod/keycloak.env
+      - ${ENV_FILE_PATH:-/etc/eigentask}/production/keycloak.env
     command: ["start", "--http-enabled=true", "--hostname-strict=false", "--proxy-headers=xforwarded", "--import-realm"]
     ports:
       - "8080:8080"
     volumes:
-      - ${ENV_FILE_PATH:-/etc/eigentask}/prod/themes:/opt/keycloak/themes:ro
+      - ${ENV_FILE_PATH:-/etc/eigentask}/production/themes:/opt/keycloak/themes:ro
       - ./keycloak/realm-export:/opt/keycloak/data/import
     healthcheck:
       test: ["CMD-SHELL", "{ printf 'GET /realms/eigentask/.well-known/openid-configuration HTTP/1.1\\r\\nHost: localhost\\r\\n\\r\\n' >&0; grep -q 'HTTP/1.1 200'; } 0<>/dev/tcp/localhost/8080"]
@@ -32,7 +32,7 @@ services:
   app-db:
     container_name: eigentask-prod-app-db
     env_file:
-      - ${ENV_FILE_PATH:-/etc/eigentask}/prod/app-db.env
+      - ${ENV_FILE_PATH:-/etc/eigentask}/production/app-db.env
     volumes:
       - app_db_data_prod:/var/lib/postgresql/data
     networks:
@@ -48,7 +48,7 @@ services:
   api:
     container_name: eigentask-prod-api
     env_file:
-      - ${ENV_FILE_PATH:-/etc/eigentask}/prod/api.env
+      - ${ENV_FILE_PATH:-/etc/eigentask}/production/api.env
     ports:
       - "8000:8000"
     networks:
@@ -57,7 +57,7 @@ services:
   web:
     container_name: eigentask-prod-web
     env_file:
-      - ${ENV_FILE_PATH:-/etc/eigentask}/prod/web.env
+      - ${ENV_FILE_PATH:-/etc/eigentask}/production/web.env
     ports:
       - "3000:3000"
     networks:


### PR DESCRIPTION
**Summary**

Env files are no longer deployed from GitHub Secrets. They must be staged on the server before deploy runs.

**Changes**

- **Deploy workflow**: Remove API_ENV, WEB_ENV, APP_DB_ENV, KEYCLOAK_ENV, KEYCLOAK_DB_ENV from secrets. Only SSH (USER, HOST, SSH_PRIVATE_KEY) and DEPLOY_PATH remain.
- **deploy.sh**: Remove the SSH block that wrote env files from secrets. Deploy only verifies env files exist at `/etc/eigentask/production/` or `/etc/eigentask/staging/` and copies Keycloak themes into that env dir.
- **docker-compose.prod.yml**: Use `production/` not `prod/` for env_file and themes paths.
- **DEPLOYMENT.md**: Document server-staged paths and reduced required secrets.