### PR TITLE
fix: Keep EigenTask on one line on login page

### DIFF
--- a/keycloak/themes/eigentask/login/resources/css/eigentask.css
+++ b/keycloak/themes/eigentask/login/resources/css/eigentask.css
@@ -58,6 +58,7 @@
   padding: 0;
   background: none;
   height: auto;
+  white-space: nowrap; /* Keep "EigenTask" on one line */
 }
 
 .kc-logo-text::before {


### PR DESCRIPTION
Adds `white-space: nowrap` to `.kc-logo-text` so the brand name "EigenTask" never wraps on the Keycloak login page.

This will be included in PR #25 (staging → main) once merged into staging.