### PR TITLE
fix: Deploy only on push to main/staging, not on PR-triggered CI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,12 +30,12 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     environment: ${{ github.ref_name == 'main' && 'production' || 'staging' }}
-    # Only deploy if CI workflow succeeded (for workflow_run triggers)
-    # TEMPORARY: Also allow deployment on feature branch for testing
+    # Only deploy on actual push to main/staging, not when CI ran due to a PR.
+    # workflow_run: only proceed if CI was triggered by push (not pull_request).
     if: |
       github.event_name == 'workflow_dispatch' ||
-      github.event_name == 'push' ||
-      (github.event.workflow_run.conclusion == 'success' && (github.event.workflow_run.head_branch == 'staging' || github.event.workflow_run.head_branch == 'main'))
+      (github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/staging')) ||
+      (github.event_name == 'workflow_run' && github.event.workflow_run.event == 'push' && github.event.workflow_run.conclusion == 'success' && (github.event.workflow_run.head_branch == 'staging' || github.event.workflow_run.head_branch == 'main'))
     
     steps:
       - name: Checkout code


### PR DESCRIPTION
**Summary**

The deploy workflow was running whenever the CI workflow completed, including when CI was triggered by a pull request. That caused deploy to run on PRs (e.g. staging -> main) instead of only on actual pushes to `main` or `staging`.

**Changes**

- **workflow_run:** Deploy now runs only when the CI run was triggered by a **push** (`github.event.workflow_run.event == 'push'`), not by `pull_request`.
- **push:** Job `if` explicitly requires push to `main` or `staging` for clarity.

**Result**

- Push to `main` or `staging`: deploy runs (direct push or after CI from that push).
- Pull request targeting `main` or `staging`: CI runs, deploy does not run.