### PR TITLE
fix: Deploy workflow use correct branch and env on workflow_run (main)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,19 +23,19 @@ on:
           - production
 
 concurrency:
-  group: deploy-${{ github.ref_name == 'main' && 'production' || 'staging' }}
+  group: deploy-${{ github.event_name == 'workflow_dispatch' && github.event.inputs.environment || (github.event_name == 'workflow_run' && (github.event.workflow_run.head_branch == 'main' && 'production' || 'staging') || (github.ref_name == 'main' && 'production' || 'staging')) }}
   cancel-in-progress: false
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    environment: ${{ github.ref_name == 'main' && 'production' || 'staging' }}
-    # Only deploy if CI workflow succeeded (for workflow_run triggers)
-    # TEMPORARY: Also allow deployment on feature branch for testing
+    environment: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.environment || (github.event_name == 'workflow_run' && (github.event.workflow_run.head_branch == 'main' && 'production' || 'staging') || (github.ref_name == 'main' && 'production' || 'staging')) }}
+    # Only deploy on actual push to main/staging, not when CI ran due to a PR.
+    # workflow_run: only proceed if CI was triggered by push (not pull_request).
     if: |
       github.event_name == 'workflow_dispatch' ||
-      github.event_name == 'push' ||
-      (github.event.workflow_run.conclusion == 'success' && (github.event.workflow_run.head_branch == 'staging' || github.event.workflow_run.head_branch == 'main'))
+      (github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/staging')) ||
+      (github.event_name == 'workflow_run' && github.event.workflow_run.event == 'push' && github.event.workflow_run.conclusion == 'success' && (github.event.workflow_run.head_branch == 'staging' || github.event.workflow_run.head_branch == 'main'))
     
     steps:
       - name: Checkout code
@@ -58,9 +58,9 @@ jobs:
           DEPLOY_HOST: ${{ secrets.HOST }}
           DEPLOY_PATH: ${{ secrets.DEPLOY_PATH || '/opt/eigentask' }}
           GITHUB_REPOSITORY: ${{ github.repository }}
-          GITHUB_REF_NAME: ${{ github.ref_name }}
+          GITHUB_REF_NAME: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_branch || github.ref_name }}
           GITHUB_SHA: ${{ github.event.workflow_run.head_sha || github.sha }}
-          ENVIRONMENT: ${{ github.ref_name == 'main' && 'production' || 'staging' }}
+          ENVIRONMENT: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.environment || (github.event_name == 'workflow_run' && (github.event.workflow_run.head_branch == 'main' && 'production' || 'staging') || (github.ref_name == 'main' && 'production' || 'staging')) }}
         run: |
           chmod +x ./scripts/deploy.sh
           ./scripts/deploy.sh

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -8,7 +8,13 @@ set -euo pipefail
 ENV="${ENVIRONMENT:-staging}"
 ENV_DIR="${ENV}"
 
-# Use the branch that triggered the deployment (or default based on environment)
+# In CI, require GITHUB_REF_NAME so misconfiguration does not silently deploy main to production
+if [ -n "${GITHUB_ACTIONS:-}" ] && [ -z "${GITHUB_REF_NAME:-}" ]; then
+    echo "ERROR: GITHUB_REF_NAME must be set when running in GitHub Actions"
+    exit 1
+fi
+
+# Use the branch that triggered the deployment (or default based on environment for local runs)
 if [ -n "${GITHUB_REF_NAME:-}" ]; then
     DEPLOY_BRANCH="${GITHUB_REF_NAME}"
 elif [ "$ENV" = "production" ]; then
@@ -56,40 +62,27 @@ ssh ${DEPLOY_USER}@${DEPLOY_HOST} << EOF
         mkdir -p $(dirname ${DEPLOY_PATH})
         git clone https://github.com/${GITHUB_REPOSITORY:-declanomara/eigentask}.git ${DEPLOY_PATH}
         cd ${DEPLOY_PATH}
-        git checkout ${DEPLOY_BRANCH} || git checkout -b ${DEPLOY_BRANCH} origin/${DEPLOY_BRANCH} || git checkout ${GITHUB_SHA}
     elif [ ! -d "${DEPLOY_PATH}/.git" ]; then
         echo "Directory exists but is not a git repository. Removing and cloning..."
         rm -rf ${DEPLOY_PATH}
         git clone https://github.com/${GITHUB_REPOSITORY:-declanomara/eigentask}.git ${DEPLOY_PATH}
         cd ${DEPLOY_PATH}
-        git checkout ${DEPLOY_BRANCH} || git checkout -b ${DEPLOY_BRANCH} origin/${DEPLOY_BRANCH} || git checkout ${GITHUB_SHA}
     else
-        echo "Directory is a git repository. Pulling latest code from ${DEPLOY_BRANCH} branch..."
         cd ${DEPLOY_PATH}
-        git fetch origin
-        # Try to checkout the branch, fallback to specific commit if branch doesn't exist
-        if git show-ref --verify --quiet refs/remotes/origin/${DEPLOY_BRANCH}; then
-            git checkout ${DEPLOY_BRANCH}
-            git pull origin ${DEPLOY_BRANCH}
-        else
-            echo "Branch ${DEPLOY_BRANCH} doesn't exist remotely, checking out commit ${GITHUB_SHA}"
-            git checkout ${GITHUB_SHA}
-        fi
     fi
+    echo "Pulling latest code from ${DEPLOY_BRANCH} branch..."
+    git fetch origin
+    if ! git show-ref --verify --quiet refs/remotes/origin/${DEPLOY_BRANCH}; then
+        echo "ERROR: Branch ${DEPLOY_BRANCH} does not exist remotely"
+        exit 1
+    fi
+    git checkout ${DEPLOY_BRANCH}
+    git pull origin ${DEPLOY_BRANCH}
     
     echo "Copying Keycloak themes to environment themes directory..."
     mkdir -p "\${ENV_PATH}/${ENV_DIR}/themes"
     cp -r keycloak/themes/* "\${ENV_PATH}/${ENV_DIR}/themes/"
     echo "Keycloak themes deployed."
-    
-    echo "Ensuring Docker network exists with correct labels..."
-    # Remove network if it exists without proper Compose labels, then let Compose create it
-    if docker network inspect ${NETWORK_NAME} >/dev/null 2>&1; then
-        if ! docker network inspect ${NETWORK_NAME} | grep -q "com.docker.compose.network"; then
-            echo "Removing existing network ${NETWORK_NAME} (missing Compose labels)..."
-            docker network rm ${NETWORK_NAME} 2>/dev/null || true
-        fi
-    fi
     
     echo "Checking disk space..."
     df -h
@@ -100,21 +93,9 @@ ssh ${DEPLOY_USER}@${DEPLOY_HOST} << EOF
     echo "Checking disk space..."
     df -h
     
-    echo "Checking Docker Buildx version..."
-    docker buildx version || echo "Buildx not installed or outdated"
-    
     echo "Building and deploying ${ENV} containers..."
     ENV_FILE_PATH=\${ENV_PATH} docker compose ${COMPOSE_FILES} pull || true
-    
-    # Use buildx if available and version is sufficient, otherwise use regular build
-    if docker buildx version 2>/dev/null | grep -q "v0\.[1-9][7-9]\|v[1-9]"; then
-        echo "Using Docker Buildx for build..."
-        ENV_FILE_PATH=\${ENV_PATH} docker compose ${COMPOSE_FILES} build
-    else
-        echo "Buildx not available or version too old, using regular build..."
-        ENV_FILE_PATH=\${ENV_PATH} DOCKER_BUILDKIT=0 docker compose ${COMPOSE_FILES} build
-    fi
-    
+    ENV_FILE_PATH=\${ENV_PATH} docker compose ${COMPOSE_FILES} build
     ENV_FILE_PATH=\${ENV_PATH} docker compose ${COMPOSE_FILES} up -d
     
     echo "Waiting for services to be healthy..."


### PR DESCRIPTION
## Why this PR targets main

The same fix was merged to **staging** in PR #34, but deployments were still going to production with main. Reason: when CI on **staging** completes, GitHub runs the **Deploy** workflow from the **default branch (main)**. So the workflow file that runs is main's version, which did not have the fix. Staging CI was therefore still using the old logic (ref_name = main, ENVIRONMENT = production) and deploying main to production.

This PR ports the fix to **main** so that the workflow that actually runs on `workflow_run` has the correct logic.

## Changes (same as PR #34)

**Workflow (`.github/workflows/deploy.yml`)**
- **Branch to deploy:** Use `workflow_run.head_branch` when event is `workflow_run`, otherwise `github.ref_name`.
- **Environment:** From triggering branch (main -> production, else staging) for push/workflow_run; from `github.event.inputs.environment` for workflow_dispatch.
- Concurrency group and job `environment` updated to match.
- **if:** Require push to main/staging (not any push) and for workflow_run require `event == 'push'` and success.

**Script (`scripts/deploy.sh`)**
- Require `GITHUB_REF_NAME` in CI so misconfiguration fails fast.
- Single checkout path; remove network label check and Buildx fallback.

## After merge

Next time CI on staging completes and triggers Deploy, the workflow from main will use `workflow_run.head_branch` = staging and deploy staging to staging.