### PR TITLE
fix: Remove (optional) from Due date in task edit menu

### DIFF
--- a/web/src/lib/components/TaskEditDrawer.svelte
+++ b/web/src/lib/components/TaskEditDrawer.svelte
@@ -307,7 +307,7 @@
       </div>
 
       <div class="flex flex-col gap-1.5">
-        <Label forId="edit-due">Due date (optional)</Label>
+        <Label forId="edit-due">Due date</Label>
         <Input
           id="edit-due"
           type="date"


### PR DESCRIPTION
The due date is required for tasks, so the "(optional)" label in the task edit menu was misleading. This change updates the label to "Due date" only.

**Changes:**
- `web/src/lib/components/TaskEditDrawer.svelte`: Changed label from "Due date (optional)" to "Due date".